### PR TITLE
Work on contamination model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ releaseSettings
 
 scalariformSettings
 
+parallelExecution in Test := false
+
 // TODO Fix this once the Adam dependency has 
 //       correct checksums. /JD 20150711
 checksums := Nil

--- a/src/main/scala/contadamination/ContaminationModel.scala
+++ b/src/main/scala/contadamination/ContaminationModel.scala
@@ -54,6 +54,8 @@ object ContaminationModel {
     // TODO check that there is only one contigName per file (right now we assume there is only one contig per file)
     val contigName = fragments.first().getContig.getContigName
 
+
+    // TODO We should not be padding the string, but rather skip once we get partial hits. /JD 20150713
     val slidingFragments = new RDDFunctions(fragments).sliding(2).flatMap({
       case Array(frag) =>
         val seq = frag.getFragmentSequence
@@ -67,6 +69,7 @@ object ContaminationModel {
     }).cache()
 
     // TODO I have concerns about the high number of entries and the user asking for a low FPR
+    // TODO We actually need to count the unique elements, not all elements!
     val numEntries = slidingFragments.count().toInt
 
     // TODO check that the cost of creating a new bloomfilter per fragment is not too high

--- a/src/main/scala/contadamination/ContaminationModel.scala
+++ b/src/main/scala/contadamination/ContaminationModel.scala
@@ -1,42 +1,53 @@
 package contadamination
 
+import java.io.File
+
 import com.twitter.algebird.{ BloomFilterMonoid, BloomFilter, BF }
 import contadamination.ContaminationModel.{ ContaminationStats, FilterContext }
 import org.apache.spark.mllib.rdd.RDDFunctions
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
 
 object ContaminationModel {
 
-  val defaultWinSize = 32
+  val defaultKmerSize = 32
   val defaultFpr = 0.1
   val defaultSeed = 0
 
-  case class FilterContext(
-    name: String, // Contig name
-    path: String, // Reference path
-    numEntries: Int, // Number of sliding windows
-    fpr: Double, // False Positive Rate
-    bloomFilter: BF // Bloom filter
-    )
+  /**
+   * The contamination BloomFilter and it's context.
+   * @param generatedFromFile File name that the filter was generated from used as identifier.
+   * @param path Reference path
+   * @param numEntries Estimated number of entires to hold
+   * @param fpr False positive rate
+   * @param bloomFilter Bloom filter
+   */
+  case class FilterContext(generatedFromFile: String,
+                           path: String,
+                           numEntries: Int,
+                           fpr: Double,
+                           bloomFilter: BF)
 
-  case class ContaminationStats(
-    numReads: Int, // Total number of reads checked
-    numNegatives: Int, // True Negatives (number of negative reads)
-    rate: Double // Contamination rate as the number of negative reads over the total number of reads
-    )
+  /**
+   * Statistics on queries against a contamination bloom filter.
+   * @param numReads  Total number of reads checked
+   * @param numNegatives True Negatives (number of negative reads)
+   * @param rate Contamination rate as the number of negative reads over the total number of reads
+   */
+  case class ContaminationStats(numReads: Long, numNegatives: Long, rate: Double)
 
   /**
    * Build a ContaminationModel from a sequence of paths
    * @param paths Sequence of FASTA files for the reference contigs
-   * @param winSize Sliding window size
+   * @param kmerSize Sliding window size
    * @param fpr False Positive Rate
    * @param adamContext ADAM Context
    * @return a ContaminationModel
    */
-  def apply(paths: Seq[String], winSize: Int = defaultWinSize, fpr: Double = defaultFpr)(implicit adamContext: ADAMContext): ContaminationModel = {
-    paths.map(ContaminationModel(_, winSize, fpr)).reduce((x, y) => x ++ y)
+  def apply(paths: Seq[String], kmerSize: Int = defaultKmerSize, fpr: Double = defaultFpr)(implicit adamContext: ADAMContext): ContaminationModel = {
+    paths.map(ContaminationModel(_, kmerSize, fpr)).reduce((x, y) => x ++ y)
   }
 
   /**
@@ -48,35 +59,26 @@ object ContaminationModel {
    * @return a ContaminationModel
    */
   def apply(path: String, winSize: Int, fpr: Double)(implicit adamContext: ADAMContext): ContaminationModel = {
-    val fragments = adamContext.loadFasta(path, winSize).cache()
+
+    val fragments = adamContext.loadSequence(path)
+    val fileName = new File(path).getName
+
     require(fragments.count() > 0, "At least one fragment is required")
 
-    // TODO check that there is only one contigName per file (right now we assume there is only one contig per file)
-    val contigName = fragments.first().getContig.getContigName
-
-
-    // TODO We should not be padding the string, but rather skip once we get partial hits. /JD 20150713
-    val slidingFragments = new RDDFunctions(fragments).sliding(2).flatMap({
-      case Array(frag) =>
-        val seq = frag.getFragmentSequence
-        for (i <- 0 until seq.size) yield seq.substring(i, winSize - i) + List.fill(i)(".").mkString
-
-      case Array(frag1, frag2) =>
-        val seq1 = frag1.getFragmentSequence
-        val seq2 = frag2.getFragmentSequence
-        val seq = seq1 + (if (seq2.size == seq1.size) seq2 else seq2 + List.fill(math.abs(seq1.size - seq2.size))(".").mkString)
-        for (i <- 0 until seq1.size) yield seq.substring(i, winSize)
-    }).cache()
-
     // TODO I have concerns about the high number of entries and the user asking for a low FPR
-    // TODO We actually need to count the unique elements, not all elements!
-    val numEntries = slidingFragments.count().toInt
+    val numEntries = fragments.countKmers(winSize).count()
+    val numEntriesAsInt =
+      if(numEntries > Int.MaxValue)
+        throw new RuntimeException("Number of k-mers was larger than IntMax, the current implementation can't handle that.")
+      else
+        numEntries.toInt
 
     // TODO check that the cost of creating a new bloomfilter per fragment is not too high
-    val width = BloomFilter.optimalWidth(numEntries, fpr)
-    val numHashes = BloomFilter.optimalNumHashes(numEntries, width)
-    slidingFragments
-      .map(frag => ContaminationModel.internalBuild(numEntries, fpr, numHashes, width, winSize, path, contigName, frag))
+    val width = BloomFilter.optimalWidth(numEntriesAsInt, fpr)
+    val numHashes = BloomFilter.optimalNumHashes(numEntriesAsInt, width)
+    fragments
+      .map(frag =>
+      ContaminationModel.internalBuild(numEntriesAsInt, fpr, numHashes, width, winSize, path, frag.getFragmentSequence, fileName))
       .reduce((x, y) => x ++ y)
   }
 
@@ -86,67 +88,68 @@ object ContaminationModel {
    * @param fpr False Positive Rate for the BloomFilter
    * @param numHashes Number of hashes for the BloomFilter
    * @param width Bit width of the BloomFilter
-   * @param winSize Size of the sliding window
-   * @param contigName Contig name
+   * @param kmerSize Size of the sliding window
    * @param fragment The initial fragment
+   * @param fileName Name of the file the filter was generated from.
    * @return a ContaminationModel
    */
-  private def internalBuild(numEntries: Int, fpr: Double, numHashes: Int, width: Int, winSize: Int,
-    path: String, contigName: String, fragment: String) = {
+  private def internalBuild(numEntries: Int, fpr: Double, numHashes: Int, width: Int, kmerSize: Int,
+                            path: String, fragment: String, fileName: String) = {
 
     val bfm = new BloomFilterMonoid(numHashes, width, defaultSeed)
-    val m = Map(contigName -> FilterContext(contigName, path, numEntries, fpr, bfm.create(fragment)))
-    new ContaminationModel(winSize, m)
+    val filterContext = FilterContext(fileName, path, numEntries, fpr, bfm.create(fragment))
+    new ContaminationModel(kmerSize, filterContext)
   }
 }
 
 /**
  * Created by chris-zen on 11/07/2015.
  */
-class ContaminationModel(val winSize: Int, val filters: Map[String, FilterContext]) {
+class ContaminationModel(val winSize: Int, val filter: FilterContext) {
+
+  private def kmersFromRead(read: String, kmerSize: Int): Iterator[String] =
+    read.iterator.sliding(kmerSize).withPartial(false).map(_.mkString)
 
   def ++(model: ContaminationModel): ContaminationModel = {
-    require(winSize == model.winSize, "It is not possible to merge models with different window size")
+    require(this.winSize == model.winSize,
+      "It is not possible to merge models with different window size")
+    require(this.filter.generatedFromFile == model.filter.generatedFromFile,
+      "Not possible to add two models generated from different files.")
 
-    val contigNames = filters.keySet ++ model.filters.keySet
-    val m = contigNames.map({ name =>
-      if (!filters.contains(name))
-        name -> model.filters(name)
-      else if (!model.filters.contains(name))
-        name -> filters(name)
-      else {
-        val filterContext = filters(name)
-        name -> filterContext.copy(
-          bloomFilter = filterContext.bloomFilter ++ model.filters(name).bloomFilter)
-      }
-    }).toMap
-    new ContaminationModel(winSize, m)
+    val addedFilters = filter.copy(bloomFilter = this.filter.bloomFilter ++ model.filter.bloomFilter)
+
+    new ContaminationModel(winSize, addedFilters)
   }
 
-  def filterPositives(reads: RDD[AlignmentRecord]): (RDD[AlignmentRecord], ContaminationStats) = {
+  private def generalFilter(reads: RDD[AlignmentRecord], kmerFilterCriteria: String => Boolean):
+    RDD[AlignmentRecord] = {
 
-    val numReads = reads.cache().count().toInt
-
-    // TODO this should be broadcasted
-    val filtersValues = filters.values
-
-    val positiveReads = reads.flatMap({ read =>
+    val matchingReads = reads.flatMap({ read =>
       val seq = read.getSequence
-      require(seq.size == winSize, "Reads length should be equal to the model sliding window size")
 
-      var hasPositive = false
-      val it = filtersValues.iterator
-      while (it.hasNext && !hasPositive)
-        hasPositive = it.next().bloomFilter.contains(seq).isTrue
+      val kmersInRead = kmersFromRead(seq, this.winSize)
+      val isAHit = kmersInRead.exists(kmer => kmerFilterCriteria(kmer))
 
-      if (hasPositive)
+      if (isAHit)
         Some(read)
       else
         None
     }).cache()
 
-    val numPositiveReads = positiveReads.count().toInt
+    matchingReads
+  }
 
+  private def positiveReadCriteria(s: String): Boolean =
+    this.filter.bloomFilter.contains(s).isTrue
+
+  private def negativeReadCriteria(s: String): Boolean =
+    !this.filter.bloomFilter.contains(s).isTrue
+
+  def filterPositives(reads: RDD[AlignmentRecord]): (RDD[AlignmentRecord], ContaminationStats) = {
+
+    val numReads = reads.cache().count()
+    val positiveReads = generalFilter(reads, positiveReadCriteria)
+    val numPositiveReads = positiveReads.count()
     val numNegativeReads = numReads - numPositiveReads
     val stats = ContaminationStats(numReads, numNegativeReads, numNegativeReads.toDouble / numReads)
 
@@ -155,49 +158,21 @@ class ContaminationModel(val winSize: Int, val filters: Map[String, FilterContex
 
   def filterNegatives(reads: RDD[AlignmentRecord]): (RDD[AlignmentRecord], ContaminationStats) = {
 
-    val numReads = reads.cache().count().toInt
-
-    // TODO this should be broadcasted
-    val filtersValues = filters.values
-
-    val negativeReads = reads.flatMap({ read =>
-      val seq = read.getSequence
-      require(seq.size == winSize, "Reads length should be equal to the model sliding window size")
-
-      val numPositives = filtersValues.map(filterContext => if (filterContext.bloomFilter.contains(seq).isTrue) 1 else 0).sum
-
-      if (numPositives == 0)
-        Some(read)
-      else
-        None
-    }).cache()
-
-    val numNegativeReads = negativeReads.count().toInt
-
+    val numReads = reads.cache().count()
+    val negativeReads = generalFilter(reads, negativeReadCriteria)
+    val numNegativeReads = negativeReads.count()
     val stats = ContaminationStats(numReads, numNegativeReads, numNegativeReads.toDouble / numReads)
 
     (negativeReads, stats)
   }
 
   def stats(reads: RDD[AlignmentRecord]): ContaminationStats = {
-    val numReads = reads.cache().count().toInt
+    val numReads = reads.cache().count()
 
-    // TODO this should be broadcasted
-    val filtersValues = filters.values
-
-    val numPositiveReads = reads.map({ read =>
-      val seq = read.getSequence
-      require(seq.size == winSize, "Reads length should be equal to the model sliding window size")
-
-      var hasPositive = false
-      val it = filtersValues.iterator
-      while (it.hasNext && !hasPositive)
-        hasPositive = it.next().bloomFilter.contains(seq).isTrue
-
-      if (hasPositive) 1 else 0
-    }).sum().toInt
-
+    val numPositiveReads =
+      generalFilter(reads, positiveReadCriteria).count()
     val numNegativeReads = numReads - numPositiveReads
+
     ContaminationStats(numReads, numNegativeReads, numNegativeReads.toDouble / numReads)
   }
 }

--- a/src/test/scala/contadamination/ContaminationModelTest.scala
+++ b/src/test/scala/contadamination/ContaminationModelTest.scala
@@ -1,14 +1,14 @@
 package contadamination
 
-import contadamination.test.utils.AdamTestContext
+import contadamination.test.utils.{ContadaminationSuite, AdamTestContext}
 import org.scalatest.FlatSpec
 
 /**
  * Created by dahljo on 7/13/15.
  */
-class ContaminationModelTest extends FlatSpec with AdamTestContext {
+class ContaminationModelTest extends ContadaminationSuite with AdamTestContext {
 
-  behavior of "ContaminationModelTest"
+  behavior of "ContaminationModel"
 
   it should "build a model from a single path" in {
     val path = "src/test/resources/mt.fasta"

--- a/src/test/scala/contadamination/ContaminationModelTest.scala
+++ b/src/test/scala/contadamination/ContaminationModelTest.scala
@@ -1,6 +1,8 @@
 package contadamination
 
 import contadamination.test.utils.{ContadaminationSuite, AdamTestContext}
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.formats.avro.NucleotideContigFragment
 import org.scalatest.FlatSpec
 
 /**
@@ -8,14 +10,36 @@ import org.scalatest.FlatSpec
  */
 class ContaminationModelTest extends ContadaminationSuite with AdamTestContext {
 
+  val path = "src/test/resources/mt.fasta"
+  val winSize = 10
+  val falsePositiveRate = 0.01
+
   behavior of "ContaminationModel"
 
-  it should "build a model from a single path" in {
-    val path = "src/test/resources/mt.fasta"
-    val winSize = 10
-    val falsePositiveRate = 0.01
+  it should "count the number of k-mers in a reference file" in {
+    def estimateNumberOfEntriesFromReference(fragments: RDD[NucleotideContigFragment], winSize: Int): Int = {
+      // TODO I have concerns about the high number of entries and the user asking for a low FPR
+      import org.bdgenomics.adam.rdd.ADAMContext._
 
-    val contaminationModel = ContaminationModel(path, winSize, falsePositiveRate)
+      val numEntries = fragments.countKmers(winSize).count()
+      val numEntriesAsInt =
+        if(numEntries > Int.MaxValue)
+          throw new RuntimeException("Number of k-mers was larger than IntMax, the current implementation can't handle that.")
+        else
+          numEntries.toInt
+      numEntriesAsInt
+    }
+
+    val fragments = adamContext.loadSequence(path)
+    val numberOfKmers =
+      estimateNumberOfEntriesFromReference(fragments = fragments, winSize = winSize)
+
+    println(numberOfKmers)
+  }
+
+  it should "build a model from a single path" in {
+    //val contaminationModel = ContaminationModel(path, winSize, falsePositiveRate)
+    pending
   }
 
   it should "build a model from a multiple paths" in {

--- a/src/test/scala/contadamination/ContaminationModelTest.scala
+++ b/src/test/scala/contadamination/ContaminationModelTest.scala
@@ -1,0 +1,36 @@
+package contadamination
+
+import contadamination.test.utils.AdamTestContext
+import org.scalatest.FlatSpec
+
+/**
+ * Created by dahljo on 7/13/15.
+ */
+class ContaminationModelTest extends FlatSpec with AdamTestContext {
+
+  behavior of "ContaminationModelTest"
+
+  it should "build a model from a single path" in {
+    val path = "src/test/resources/mt.fasta"
+    val winSize = 10
+    val falsePositiveRate = 0.01
+
+    val contaminationModel = ContaminationModel(path, winSize, falsePositiveRate)
+  }
+
+  it should "build a model from a multiple paths" in {
+    pending
+  }
+
+  it should "be possible to add two contamination models" in {
+    pending
+  }
+
+  it should "be possible filter positives" in {
+    pending
+  }
+
+  it should "be possible get statistics" in {
+    pending
+  }
+}

--- a/src/test/scala/contadamination/bloom/BloomFilterBuilderTest.scala
+++ b/src/test/scala/contadamination/bloom/BloomFilterBuilderTest.scala
@@ -3,20 +3,14 @@ package contadamination.bloom
 import java.io.File
 
 import com.twitter.algebird.ApproximateBoolean
-import contadamination.test.utils.ContadaminationSuite
+import contadamination.test.utils.{AdamTestContext, ContadaminationSuite}
 import org.apache.spark.{ SparkConf, SparkContext }
 import org.scalatest._
 
 /**
  * Created by dahljo on 7/9/15.
  */
-class BloomFilterBuilderTest extends ContadaminationSuite {
-
-  def createSparkContext(): SparkContext = {
-    val conf = new SparkConf().setAppName("SparkQ").setMaster("local[1]")
-    val sc = new SparkContext(conf)
-    sc
-  }
+class BloomFilterBuilderTest extends ContadaminationSuite with AdamTestContext {
 
   val probOfFalsePositive = 0.0005
   val windowSize = 30
@@ -24,11 +18,9 @@ class BloomFilterBuilderTest extends ContadaminationSuite {
 
   test("createBloomFilter") {
 
-    val sc = createSparkContext()
-
     val bloomfilterBuilder =
       new BloomFilterBuilder(
-        sc,
+        adamContext,
         probOfFalsePositive,
         windowSize)
 

--- a/src/test/scala/contadamination/bloom/BloomFilterBuilderTest.scala
+++ b/src/test/scala/contadamination/bloom/BloomFilterBuilderTest.scala
@@ -16,8 +16,9 @@ class BloomFilterBuilderTest extends ContadaminationSuite with AdamTestContext {
   val windowSize = 30
   val reference: File = new File("src/test/resources/mt.fasta")
 
-  test("createBloomFilter") {
+  behavior of "BloomFilterBuilder"
 
+  it should "construct a correct filer" in {
     val bloomfilterBuilder =
       new BloomFilterBuilder(
         adamContext,
@@ -30,5 +31,6 @@ class BloomFilterBuilderTest extends ContadaminationSuite with AdamTestContext {
     assert(bloomFilter.contains(first30bases).isTrue)
     assert(!bloomFilter.contains("Z" * windowSize).isTrue)
   }
+
 
 }

--- a/src/test/scala/contadamination/results/ContaminationFilterTest.scala
+++ b/src/test/scala/contadamination/results/ContaminationFilterTest.scala
@@ -13,12 +13,13 @@ class ContaminationFilterTest extends ContadaminationSuite {
   val bloomFilterX = bloomFilterCreater.create("AAA")
   val contaminationFilterX = ContaminationFilter(bloomFilterX, "test_organism", totalNbrOfQueries = 2, hits = 1)
 
-  test("testContaminationRate") {
+  behavior of "ContaminationModel"
+
+  it should "compute a correct contamination rate" in {
     assert(contaminationFilterX.contaminationRate === 0.5)
   }
 
-  test("testQuery") {
-
+  it should "be possible to query the filter" in {
     val queryForTrippleA = contaminationFilterX.query("AAA")
     assert(queryForTrippleA.hits === contaminationFilterX.hits + 1)
     assert(queryForTrippleA.totalNbrOfQueries === contaminationFilterX.totalNbrOfQueries + 1)
@@ -27,9 +28,4 @@ class ContaminationFilterTest extends ContadaminationSuite {
     assert(queryForTrippleT.hits === contaminationFilterX.hits)
     assert(queryForTrippleT.totalNbrOfQueries === contaminationFilterX.totalNbrOfQueries + 1)
   }
-
-  test("testToString") {
-    pending
-  }
-
 }

--- a/src/test/scala/contadamination/test/utils/AdamTestContext.scala
+++ b/src/test/scala/contadamination/test/utils/AdamTestContext.scala
@@ -1,0 +1,28 @@
+package contadamination.test.utils
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.bdgenomics.adam.rdd.ADAMContext
+import org.scalatest.{BeforeAndAfterAll, Suite, BeforeAndAfter}
+
+object AdamTestContextSingleton {
+
+  def createSparkContext(): SparkContext = {
+    val conf = new SparkConf().setAppName("contadamination").setMaster("local[1]")
+    val sc = new SparkContext(conf)
+    sc
+  }
+
+  val sparkContext = createSparkContext()
+  val adamContext = new ADAMContext(sparkContext)
+}
+
+/**
+ * Created by dahljo on 7/13/15.
+ */
+trait AdamTestContext {
+
+  this: Suite =>
+
+  implicit val adamContext = AdamTestContextSingleton.adamContext
+
+}

--- a/src/test/scala/contadamination/test/utils/AdamTestContext.scala
+++ b/src/test/scala/contadamination/test/utils/AdamTestContext.scala
@@ -2,27 +2,48 @@ package contadamination.test.utils
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.bdgenomics.adam.rdd.ADAMContext
-import org.scalatest.{BeforeAndAfterAll, Suite, BeforeAndAfter}
+import org.scalatest.BeforeAndAfter
 
-object AdamTestContextSingleton {
-
-  def createSparkContext(): SparkContext = {
-    val conf = new SparkConf().setAppName("contadamination").setMaster("local[1]")
-    val sc = new SparkContext(conf)
-    sc
-  }
-
-  val sparkContext = createSparkContext()
-  val adamContext = new ADAMContext(sparkContext)
-}
 
 /**
  * Created by dahljo on 7/13/15.
  */
-trait AdamTestContext {
+trait AdamTestContext extends BeforeAndAfter {
 
-  this: Suite =>
+  this: ContadaminationSuite =>
 
-  implicit val adamContext = AdamTestContextSingleton.adamContext
+  private val master = "local[2]"
+  private val appName = "contadamination"
+
+  private var sparkContext: SparkContext = _
+  implicit var adamContext: ADAMContext = _
+
+  before {
+    if(sparkContext == null) {
+      System.clearProperty("spark.driver.port")
+      System.clearProperty("spark.hostPort")
+      System.clearProperty("spark.master.port")
+
+      val conf = new SparkConf()
+        .setMaster(master)
+        .setAppName(appName)
+
+      sparkContext = new SparkContext(conf)
+      adamContext = new ADAMContext(sparkContext)
+    }
+
+  }
+
+  after {
+    if (sparkContext != null) {
+      sparkContext.stop()
+      sparkContext = null
+      adamContext = null
+
+      System.clearProperty("spark.driver.port")
+      System.clearProperty("spark.hostPort")
+      System.clearProperty("spark.master.port")
+    }
+  }
 
 }

--- a/src/test/scala/contadamination/test/utils/ContadaminationSuite.scala
+++ b/src/test/scala/contadamination/test/utils/ContadaminationSuite.scala
@@ -1,8 +1,8 @@
 package contadamination.test.utils
 
-import org.scalatest.{ Assertions, FunSuite }
+import org.scalatest.{FlatSpec, Assertions, FunSuite}
 
 /**
  * Created by dahljo on 7/10/15.
  */
-trait ContadaminationSuite extends FunSuite with Assertions {}
+trait ContadaminationSuite extends FlatSpec with Assertions {}


### PR DESCRIPTION
A few different changes:
- Using the built in ADAM support to count kmers in the reference
- Sliding over the read to generate k-mers to search for
- This should now also support multiple contigs in a fasta file
- Started adding tests, but got stuck with the things above so I never real got around to writing them.

At the moment it's all untested, but I'm to tired to go on. Bugs will be abundant... :p
